### PR TITLE
Remove the push trigger from the Python package workflow

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,6 +1,6 @@
 name: Python package
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
I don't think we need the Actions workflow to be triggered on `push` events, just on `pull_request` events – at the moment the checks are essentially duplicated.