### PR TITLE
MPM-599 raise exception in iter_chuncks

### DIFF
--- a/dataengineeringutils3/db.py
+++ b/dataengineeringutils3/db.py
@@ -62,20 +62,24 @@ class SelectQuerySet:
         for r in self.cursor:
             yield r
 
-    def iter_chunks(self):
+    def iter_chunks(self, raise_error=False):
         results = self.cursor.fetchmany(self.fetch_size)
         while results:
             yield results
             try:
                 results = self.cursor.fetchmany(self.fetch_size)
             except Exception as e:
-                raise e
+                if raise_error:
+                    raise e
+                else:
+                    results = None
+                    break
 
     @property
     def headers(self):
         """Return column names"""
         return [c[0] for c in self.cursor.description]
 
-    def write_to_file(self, file_writer, line_transform=lambda x: x):
-        for results in self.iter_chunks():
+    def write_to_file(self, file_writer, line_transform=lambda x: x, raise_error=False):
+        for results in self.iter_chunks(raise_error=raise_error):
             file_writer.write_lines(results, line_transform)

--- a/dataengineeringutils3/db.py
+++ b/dataengineeringutils3/db.py
@@ -69,8 +69,7 @@ class SelectQuerySet:
             try:
                 results = self.cursor.fetchmany(self.fetch_size)
             except Exception as e:
-                print(f"Unexpected {e=}, {type(e)=}")
-                raise
+                raise e
 
     @property
     def headers(self):

--- a/dataengineeringutils3/db.py
+++ b/dataengineeringutils3/db.py
@@ -68,9 +68,9 @@ class SelectQuerySet:
             yield results
             try:
                 results = self.cursor.fetchmany(self.fetch_size)
-            except Exception:
-                results = None
-                break
+            except Exception as e:
+                print(f"Unexpected {e=}, {type(e)=}")
+                raise
 
     @property
     def headers(self):


### PR DESCRIPTION
Add the option to raise an exception when iter_chunks fails. This is switched off by default to ensure backwards compatibility.