### PR TITLE
Rollback downlaod artifact to v4

### DIFF
--- a/.github/workflows/poetry-pypi-release.yml
+++ b/.github/workflows/poetry-pypi-release.yml
@@ -31,7 +31,7 @@ jobs:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
     steps:
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v4
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Rollback download-artifact to v4 due to changes in how it handles downloading artifacts in later versions. Matches data_linter set up